### PR TITLE
Slack Alert Formatting

### DIFF
--- a/handlers/notification/slack.json
+++ b/handlers/notification/slack.json
@@ -7,6 +7,7 @@
     "bot_name": "optional bot name, defaults to slack defined",
     "proxy_addr": "optional - your proxy address for http proxy, like squid, i.e. 192.168.10.100",
     "proxy_port": "optional - should be port used by proxy, i.e. 3128",
-    "markdown_enabled": false
+    "markdown_enabled": false,
+    "sensu_server_url": "optional - used for linking check and client from the notification to your sensu server"
   }
 }


### PR DESCRIPTION
Updated `slack.json` to allow defining a Sensu server url (to be used for linking checks and clients to that Sensu server). Also updated `slack.rb` to read the new variable for linking, include context for the notification and format it to make it readable.

The Slack notification message for a Sensu alert would look something like this:

![sensualertslacknotification](https://cloud.githubusercontent.com/assets/16213952/11670623/00e0828c-9dd1-11e5-869e-d5c1707d2182.png)
